### PR TITLE
State Check on Startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+schemas/*.compiled

--- a/extension.js
+++ b/extension.js
@@ -513,41 +513,162 @@ export default class CustomQuickToggleExtension extends Extension {
         buttonClick5 = this._settings.get_int('buttonclick5-setting');
         buttonClick6 = this._settings.get_int('buttonclick6-setting');
 
-        switch (initialState1) {
-            case 0: toggleState1 = true;  this._settings.set_boolean('togglestate1-setting', true);  break;
-            case 1: toggleState1 = false; this._settings.set_boolean('togglestate1-setting', false); break;
-            case 2: toggleState1 = this._settings.get_boolean('togglestate1-setting');               break;
+        function checkDynamicState(command, callback) {
+          try {
+            let [success, pid] = GLib.spawn_async(
+              null,
+              ["/bin/bash", "-c", command],
+              null,
+              GLib.SpawnFlags.SEARCH_PATH |
+                GLib.SpawnFlags.DO_NOT_REAP_CHILD |
+                GLib.SpawnFlags.STDOUT_TO_DEV_NULL,
+              null,
+            );
+
+            if (success) {
+              GLib.child_watch_add(GLib.PRIORITY_DEFAULT, pid, (pid, status) => {
+                try {
+                  let result = status === 0; // Assuming exit code 0 means true
+                  callback(result);
+                } catch (e) {
+                  console.log(`Error in dynamic state callback: ${e}`);
+                  callback(false);
+                }
+              });
+            } else {
+              console.log("Failed to spawn command");
+              callback(false);
+            }
+          } catch (e) {
+            console.log(`Error checking dynamic state: ${e}`);
+            callback(false);
+          }
         }
+
+        switch (initialState1) {
+          case 0:
+            toggleState1 = true;
+            break;
+          case 1:
+            toggleState1 = false;
+            break;
+          case 2:
+            toggleState1 = this._settings.get_boolean("togglestate1-setting");
+            break;
+          case 3:
+            let cmd = this._settings.get_string("checkcommand1-setting");
+            checkDynamicState(cmd, (result) => {
+              toggleState1 = result;
+              this._indicator1.toggle1.checked = result;
+            });
+            break;
+        }
+
         switch (initialState2) {
-            case 0: toggleState2 = true;  this._settings.set_boolean('togglestate2-setting', true);  break;
-            case 1: toggleState2 = false; this._settings.set_boolean('togglestate2-setting', false); break;
-            case 2: toggleState2 = this._settings.get_boolean('togglestate2-setting');               break;
+          case 0:
+            toggleState2 = true;
+            this._settings.set_boolean("togglestate2-setting", true);
+            break;
+          case 1:
+            toggleState2 = false;
+            this._settings.set_boolean("togglestate2-setting", false);
+            break;
+          case 2:
+            toggleState2 = this._settings.get_boolean("togglestate2-setting");
+            break;
+          case 3:
+            let cmd = this._settings.get_string("checkcommand2-setting");
+            checkDynamicState(cmd, (result) => {
+              toggleState2 = result;
+              this._indicator2.toggle1.checked = result;
+            });
+            break;
         }
         switch (initialState3) {
-            case 0: toggleState3 = true;  this._settings.set_boolean('togglestate3-setting', true);  break;
-            case 1: toggleState3 = false; this._settings.set_boolean('togglestate3-setting', false); break;
-            case 2: toggleState3 = this._settings.get_boolean('togglestate3-setting');               break;
+          case 0:
+            toggleState3 = true;
+            this._settings.set_boolean("togglestate3-setting", true);
+            break;
+          case 1:
+            toggleState3 = false;
+            this._settings.set_boolean("togglestate3-setting", false);
+            break;
+          case 2:
+            toggleState3 = this._settings.get_boolean("togglestate3-setting");
+            break;
+          case 3:
+            let cmd = this._settings.get_string("checkcommand3-setting");
+            checkDynamicState(cmd, (result) => {
+              toggleState3 = result;
+              this._indicator3.toggle1.checked = result;
+            });
+            break;
         }
         switch (initialState4) {
-            case 0: toggleState4 = true;  this._settings.set_boolean('togglestate4-setting', true);  break;
-            case 1: toggleState4 = false; this._settings.set_boolean('togglestate4-setting', false); break;
-            case 2: toggleState4 = this._settings.get_boolean('togglestate4-setting');               break;
+          case 0:
+            toggleState4 = true;
+            this._settings.set_boolean("togglestate4-setting", true);
+            break;
+          case 1:
+            toggleState4 = false;
+            this._settings.set_boolean("togglestate4-setting", false);
+            break;
+          case 2:
+            toggleState4 = this._settings.get_boolean("togglestate4-setting");
+            break;
+          case 3:
+            let cmd = this._settings.get_string("checkcommand4-setting");
+            checkDynamicState(cmd, (result) => {
+              toggleState4 = result;
+              this._indicator4.toggle1.checked = result;
+            });
+            break;
         }
         switch (initialState5) {
-            case 0: toggleState5 = true;  this._settings.set_boolean('togglestate5-setting', true);  break;
-            case 1: toggleState5 = false; this._settings.set_boolean('togglestate5-setting', false); break;
-            case 2: toggleState5 = this._settings.get_boolean('togglestate5-setting');               break;
+          case 0:
+            toggleState5 = true;
+            this._settings.set_boolean("togglestate5-setting", true);
+            break;
+          case 1:
+            toggleState5 = false;
+            this._settings.set_boolean("togglestate5-setting", false);
+            break;
+          case 2:
+            toggleState5 = this._settings.get_boolean("togglestate5-setting");
+            break;
+          case 3:
+            let cmd = this._settings.get_string("checkcommand5-setting");
+            checkDynamicState(cmd, (result) => {
+              toggleState5 = result;
+              this._indicator5.toggle1.checked = result;
+            });
+            break;
         }
         switch (initialState6) {
-            case 0: toggleState6 = true;  this._settings.set_boolean('togglestate6-setting', true);  break;
-            case 1: toggleState6 = false; this._settings.set_boolean('togglestate6-setting', false); break;
-            case 2: toggleState6 = this._settings.get_boolean('togglestate6-setting');               break;
+          case 0:
+            toggleState6 = true;
+            this._settings.set_boolean("togglestate6-setting", true);
+            break;
+          case 1:
+            toggleState6 = false;
+            this._settings.set_boolean("togglestate6-setting", false);
+            break;
+          case 2:
+            toggleState6 = this._settings.get_boolean("togglestate6-setting");
+            break;
+          case 3:
+            let cmd = this._settings.get_string("checkcommand6-setting");
+            checkDynamicState(cmd, (result) => {
+              toggleState6 = result;
+              this._indicator6.toggle1.checked = result;
+            });
+            break;
         }
-        
+
         refreshIndicator.call(this);
 
-    
-        // Run commands at boot 
+
+        // Run commands at boot
         let toggleStates = [ toggleState1, toggleState2, toggleState3, toggleState4, toggleState5, toggleState6 ];
         for (let i = 1; i <= numToggleButtons; i++) {
             const runAtBootSetting = this._settings.get_boolean(`runcommandatboot${i}-setting`);

--- a/prefs.js
+++ b/prefs.js
@@ -100,7 +100,7 @@ export default class CustomCommandTogglePreferences extends ExtensionPreferences
 
             const optionList = new Gtk.StringList();
             [_('On'), _('Off'), _('Previous state')].forEach(choice => optionList.append(choice));
-        
+
             const comboRow = new Adw.ComboRow({
                 title: _('Initial State'),
                 subtitle: _('State of the toggle button at login/startup'),
@@ -108,7 +108,26 @@ export default class CustomCommandTogglePreferences extends ExtensionPreferences
                 selected: window._settings.get_int(`initialtogglestate${pageIndex}-setting`),
             });
             group3.add(comboRow);
-        
+
+            const checkCommandRow = new Adw.EntryRow({
+              title: _("Check State Command:"),
+            });
+            checkCommandRow.visible = comboRow.selected === 3;
+            group3.add(checkCommandRow);
+
+            // Show/hide check fields based on selected option
+            comboRow.connect("notify::selected", () => {
+              checkCommandRow.visible = comboRow.selected === 3;
+            });
+
+            // Add bindings
+            window._settings.bind(
+              `checkcommand${pageIndex}-setting`,
+              checkCommandRow,
+              "text",
+              Gio.SettingsBindFlags.DEFAULT,
+            );
+
             const expanderRow = new Adw.ExpanderRow({
                 title: _('Run Command at Startup'),
                 subtitle: _('Run associated toggle command at login/startup'),

--- a/prefs.js
+++ b/prefs.js
@@ -115,12 +115,10 @@ export default class CustomCommandTogglePreferences extends ExtensionPreferences
             checkCommandRow.visible = comboRow.selected === 3;
             group3.add(checkCommandRow);
 
-            // Show/hide check fields based on selected option
             comboRow.connect("notify::selected", () => {
               checkCommandRow.visible = comboRow.selected === 3;
             });
 
-            // Add bindings
             window._settings.bind(
               `checkcommand${pageIndex}-setting`,
               checkCommandRow,

--- a/prefs.js
+++ b/prefs.js
@@ -99,7 +99,7 @@ export default class CustomCommandTogglePreferences extends ExtensionPreferences
             groups.push(group3);
 
             const optionList = new Gtk.StringList();
-            [_('On'), _('Off'), _('Previous state')].forEach(choice => optionList.append(choice));
+            [_('On'), _('Off'), _('Previous state'), _('Check state dynamically')].forEach(choice => optionList.append(choice));
 
             const comboRow = new Adw.ComboRow({
                 title: _('Initial State'),

--- a/schemas/org.gnome.shell.extensions.custom-command-toggle.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.custom-command-toggle.gschema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
   <schema id="org.gnome.shell.extensions.custom-command-toggle" path="/org/gnome/shell/extensions/custom-command-toggle/">
-    
+
     <key name="numbuttons-setting" type="i">
       <default>1</default>
     </key>
@@ -28,11 +28,6 @@
       <default>''</default>
       <summary>Check state command for button 1</summary>
       <description>Command to check current state for button 1</description>
-    </key>
-    <key name="checkregex1-setting" type="s">
-      <default>''</default>
-      <summary>Check state regex for button 1</summary>
-      <description>Regex pattern to match for ON state for button 1</description>
     </key>
     <key name="runcommandatboot1-setting" type="b">
       <default>false</default>
@@ -76,11 +71,6 @@
       <summary>Check state command for button 2</summary>
       <description>Command to check current state for button 2</description>
     </key>
-    <key name="checkregex2-setting" type="s">
-      <default>''</default>
-      <summary>Check state regex for button 2</summary>
-      <description>Regex pattern to match for ON state for button 2</description>
-    </key>
     <key name="runcommandatboot2-setting" type="b">
       <default>false</default>
     </key>
@@ -95,7 +85,7 @@
     </key>
     <key name="closemenu2-setting" type="b">
       <default>false</default>
-    </key>    
+    </key>
     <key name='keybinding2-setting' type='as'>
       <default><![CDATA[['']]]></default>
     </key>
@@ -170,11 +160,6 @@
       <summary>Check state command for button 2</summary>
       <description>Command to check current state for button 2</description>
     </key>
-    <key name="checkregex4-setting" type="s">
-      <default>''</default>
-      <summary>Check state regex for button 2</summary>
-      <description>Regex pattern to match for ON state for button 2</description>
-    </key>
     <key name="runcommandatboot4-setting" type="b">
       <default>false</default>
     </key>
@@ -189,7 +174,7 @@
     </key>
     <key name="closemenu4-setting" type="b">
       <default>false</default>
-    </key>    
+    </key>
     <key name='keybinding4-setting' type='as'>
       <default><![CDATA[['']]]></default>
     </key>
@@ -217,11 +202,6 @@
       <summary>Check state command for button 2</summary>
       <description>Command to check current state for button 2</description>
     </key>
-    <key name="checkregex5-setting" type="s">
-      <default>''</default>
-      <summary>Check state regex for button 2</summary>
-      <description>Regex pattern to match for ON state for button 2</description>
-    </key>
     <key name="runcommandatboot5-setting" type="b">
       <default>false</default>
     </key>
@@ -239,7 +219,7 @@
     </key>
     <key name='keybinding5-setting' type='as'>
       <default><![CDATA[['']]]></default>
-    </key>      
+    </key>
 
     <key name="entryrow16-setting" type="s">
       <default>'notify-send "Custom Command Toggle" "Button 6 toggled on"'</default>
@@ -264,11 +244,6 @@
       <summary>Check state command for button 2</summary>
       <description>Command to check current state for button 2</description>
     </key>
-    <key name="checkregex6-setting" type="s">
-      <default>''</default>
-      <summary>Check state regex for button 2</summary>
-      <description>Regex pattern to match for ON state for button 2</description>
-    </key>
     <key name="runcommandatboot6-setting" type="b">
       <default>false</default>
     </key>
@@ -283,10 +258,10 @@
     </key>
     <key name="closemenu6-setting" type="b">
       <default>false</default>
-    </key>    
+    </key>
     <key name='keybinding6-setting' type='as'>
       <default><![CDATA[['']]]></default>
-    </key>        
+    </key>
 
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.custom-command-toggle.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.custom-command-toggle.gschema.xml
@@ -24,6 +24,16 @@
     <key name="togglestate1-setting" type="b">
       <default>false</default>
     </key>
+    <key name="checkcommand1-setting" type="s">
+      <default>''</default>
+      <summary>Check state command for button 1</summary>
+      <description>Command to check current state for button 1</description>
+    </key>
+    <key name="checkregex1-setting" type="s">
+      <default>''</default>
+      <summary>Check state regex for button 1</summary>
+      <description>Regex pattern to match for ON state for button 1</description>
+    </key>
     <key name="runcommandatboot1-setting" type="b">
       <default>false</default>
     </key>
@@ -60,6 +70,16 @@
     </key>
     <key name="togglestate2-setting" type="b">
       <default>false</default>
+    </key>
+    <key name="checkcommand2-setting" type="s">
+      <default>''</default>
+      <summary>Check state command for button 2</summary>
+      <description>Command to check current state for button 2</description>
+    </key>
+    <key name="checkregex2-setting" type="s">
+      <default>''</default>
+      <summary>Check state regex for button 2</summary>
+      <description>Regex pattern to match for ON state for button 2</description>
     </key>
     <key name="runcommandatboot2-setting" type="b">
       <default>false</default>
@@ -98,12 +118,22 @@
     <key name="togglestate3-setting" type="b">
       <default>false</default>
     </key>
+    <key name="checkcommand3-setting" type="s">
+      <default>''</default>
+      <summary>Check state command for button 2</summary>
+      <description>Command to check current state for button 2</description>
+    </key>
+    <key name="checkregex3-setting" type="s">
+      <default>''</default>
+      <summary>Check state regex for button 2</summary>
+      <description>Regex pattern to match for ON state for button 2</description>
+    </key>
     <key name="runcommandatboot3-setting" type="b">
       <default>false</default>
     </key>
     <key name="delaytime3-setting" type="i">
       <default>3</default>
-    </key>  
+    </key>
     <key name="showindicator3-setting" type="b">
       <default>true</default>
     </key>
@@ -112,7 +142,7 @@
     </key>
     <key name="closemenu3-setting" type="b">
       <default>false</default>
-    </key>    
+    </key>
     <key name='keybinding3-setting' type='as'>
       <default><![CDATA[['']]]></default>
     </key>
@@ -134,6 +164,16 @@
     </key>
     <key name="togglestate4-setting" type="b">
       <default>false</default>
+    </key>
+    <key name="checkcommand4-setting" type="s">
+      <default>''</default>
+      <summary>Check state command for button 2</summary>
+      <description>Command to check current state for button 2</description>
+    </key>
+    <key name="checkregex4-setting" type="s">
+      <default>''</default>
+      <summary>Check state regex for button 2</summary>
+      <description>Regex pattern to match for ON state for button 2</description>
     </key>
     <key name="runcommandatboot4-setting" type="b">
       <default>false</default>
@@ -172,6 +212,16 @@
     <key name="togglestate5-setting" type="b">
       <default>false</default>
     </key>
+    <key name="checkcommand5-setting" type="s">
+      <default>''</default>
+      <summary>Check state command for button 2</summary>
+      <description>Command to check current state for button 2</description>
+    </key>
+    <key name="checkregex5-setting" type="s">
+      <default>''</default>
+      <summary>Check state regex for button 2</summary>
+      <description>Regex pattern to match for ON state for button 2</description>
+    </key>
     <key name="runcommandatboot5-setting" type="b">
       <default>false</default>
     </key>
@@ -208,6 +258,16 @@
     </key>
     <key name="togglestate6-setting" type="b">
       <default>false</default>
+    </key>
+    <key name="checkcommand6-setting" type="s">
+      <default>''</default>
+      <summary>Check state command for button 2</summary>
+      <description>Command to check current state for button 2</description>
+    </key>
+    <key name="checkregex6-setting" type="s">
+      <default>''</default>
+      <summary>Check state regex for button 2</summary>
+      <description>Regex pattern to match for ON state for button 2</description>
     </key>
     <key name="runcommandatboot6-setting" type="b">
       <default>false</default>


### PR DESCRIPTION
Hey there! 👋 Thanks for creating this awesome extension - it's been really helpful for my workflow!

I wanted to contribute a small but useful feature that I think others might benefit from too:

feat: Add state checking functionality for toggle commands

I added the ability to check the current state of services/commands before toggling. The extension now uses command exit codes to determine toggle states:
- Exit code 0: Toggle shows as enabled
- Non-zero exit code: Toggle shows as disabled

For example, I'm using it with Docker like this:
`systemctl is-active docker.service`
- Returns exit code 0 when Docker is running
- Returns exit code 3 when it's stopped
- The toggle automatically reflects the actual Docker state 🎉

This is super helpful if you (like me) frequently start/stop services and want the UI to always show the correct state.

Let me know if you'd like me to adjust anything or if you have questions! Happy to help make this even better. 😊